### PR TITLE
[codex] Surface protected zone overflow

### DIFF
--- a/src/memguard/core.py
+++ b/src/memguard/core.py
@@ -112,18 +112,44 @@ class Memory:
         active_budget = max(int(token_budget * 0.35), 1)
         buffer_budget = max(token_budget - protected_budget - active_budget, 0)
 
-        protected_selected = _fit_items_to_budget(protected, protected_budget)
-        active_selected = _fit_items_to_budget(active, active_budget)
-        buffer_selected = _fit_items_to_budget(buffer_items, buffer_budget)
+        protected_fit = _fit_items_to_budget_detailed(protected, protected_budget)
+        active_fit = _fit_items_to_budget_detailed(active, active_budget)
+        buffer_fit = _fit_items_to_budget_detailed(buffer_items, buffer_budget)
+
+        protected_selected = protected_fit["selected"]
+        active_selected = active_fit["selected"]
+        buffer_selected = buffer_fit["selected"]
 
         prompt = _render_context(protected_selected, active_selected, buffer_selected)
         return {
             "query": query,
             "token_budget": token_budget,
+            "budgets": {
+                "protected": protected_budget,
+                "active": active_budget,
+                "buffer": buffer_budget,
+            },
             "zones": {
                 "protected": [item.to_dict() for item in protected_selected],
                 "active": [item.to_dict() for item in active_selected],
                 "buffer": [item.to_dict() for item in buffer_selected],
+            },
+            "overflow": {
+                "protected": _selection_overflow_summary(
+                    zone="protected",
+                    fit=protected_fit,
+                    budget=protected_budget,
+                ),
+                "active": _selection_overflow_summary(
+                    zone="active",
+                    fit=active_fit,
+                    budget=active_budget,
+                ),
+                "buffer": _selection_overflow_summary(
+                    zone="buffer",
+                    fit=buffer_fit,
+                    budget=buffer_budget,
+                ),
             },
             "prompt": prompt,
         }
@@ -147,6 +173,10 @@ class Memory:
             "integrity": {
                 "protected_loaded": len(loaded_ids),
                 "protected_expected": len(protected),
+                "protected_overflow": context["overflow"]["protected"]["overflowed"],
+                "protected_omitted": context["overflow"]["protected"]["omitted_count"],
+                "protected_budget": context["overflow"]["protected"]["budget"],
+                "protected_used_tokens": context["overflow"]["protected"]["used_tokens"],
                 "instruction_checks_passed": passed_checks,
                 "instruction_checks_failed": failed_checks,
                 "instruction_checks_uncertain": uncertain_checks,
@@ -156,6 +186,7 @@ class Memory:
             },
             "conflicts": conflicts,
             "drift": drift,
+            "overflow": context["overflow"],
         }
 
     def replay(
@@ -209,6 +240,7 @@ class Memory:
             loaded_memory_map=loaded_memory_map,
             source=source,
             context_zones=context["zones"],
+            overflow=context["overflow"],
         )
 
     def observe_action(
@@ -254,6 +286,7 @@ class Memory:
             loaded_memory_map=loaded_memory_map,
             source=source,
             context_zones=context["zones"],
+            overflow=context["overflow"],
             event_context=event_context,
         )
         observed["action"] = event_context
@@ -411,6 +444,7 @@ class Memory:
         loaded_memory_map: Dict[str, MemoryItem],
         source: str,
         context_zones: Dict[str, List[Dict[str, Any]]],
+        overflow: Optional[Dict[str, Any]] = None,
         event_context: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         observations: List[Dict[str, Any]] = []
@@ -462,6 +496,7 @@ class Memory:
             "uncertain": uncertain_count,
             "observations": observations,
             "skipped": skipped,
+            "overflow": overflow or {},
         }
 
     def _record_compliance_event(
@@ -616,15 +651,55 @@ def _render_zone(title: str, items: List[MemoryItem]) -> str:
 
 
 def _fit_items_to_budget(items: List[MemoryItem], budget: int) -> List[MemoryItem]:
+    return _fit_items_to_budget_detailed(items, budget)["selected"]
+
+
+def _fit_items_to_budget_detailed(items: List[MemoryItem], budget: int) -> Dict[str, Any]:
     selected: List[MemoryItem] = []
+    omitted: List[Dict[str, Any]] = []
     used = 0
     for item in items:
         item_cost = _estimate_tokens(item.content)
         if selected and used + item_cost > budget:
+            omitted.append(
+                {
+                    "item": item,
+                    "estimated_tokens": item_cost,
+                    "reason": "budget_exceeded",
+                }
+            )
             continue
         selected.append(item)
         used += item_cost
-    return selected
+    return {
+        "selected": selected,
+        "omitted": omitted,
+        "used_tokens": used,
+        "candidate_tokens": sum(_estimate_tokens(item.content) for item in items),
+    }
+
+
+def _selection_overflow_summary(*, zone: str, fit: Dict[str, Any], budget: int) -> Dict[str, Any]:
+    used_tokens = int(fit["used_tokens"])
+    omitted = list(fit["omitted"])
+    return {
+        "zone": zone,
+        "budget": budget,
+        "used_tokens": used_tokens,
+        "candidate_tokens": int(fit["candidate_tokens"]),
+        "selected_count": len(fit["selected"]),
+        "omitted_count": len(omitted),
+        "overflowed": bool(omitted) or used_tokens > budget,
+        "omitted": [
+            {
+                "id": entry["item"].id,
+                "instruction": entry["item"].content,
+                "estimated_tokens": entry["estimated_tokens"],
+                "reason": f"{zone}_budget_exceeded",
+            }
+            for entry in omitted
+        ],
+    }
 
 
 def _estimate_tokens(text: str) -> int:

--- a/src/memguard/guard.py
+++ b/src/memguard/guard.py
@@ -153,6 +153,12 @@ class MemoryGuard:
             "not_applicable": [item["instruction"] for item in not_applicable_details],
             "details": result["observations"],
             "skipped_details": skipped_details,
+            "protected_overflow": result.get("overflow", {}).get("protected", {}).get("overflowed", False),
+            "omitted_protected_instructions": [
+                item["instruction"]
+                for item in result.get("overflow", {}).get("protected", {}).get("omitted", [])
+            ],
+            "overflow": result.get("overflow", {}),
         }
 
     def reminder(self) -> str:
@@ -182,6 +188,8 @@ class MemoryGuard:
         return {
             "protected": integrity["protected_expected"],
             "active": stats["total"] - integrity["protected_expected"],
+            "protected_overflow": integrity.get("protected_overflow", False),
+            "protected_omitted": integrity.get("protected_omitted", 0),
             "drift_warnings": integrity["drift_warnings"],
             "conflicts": integrity["conflicts_detected"],
             "observed_checks": total_checks,

--- a/tests/test_guard.py
+++ b/tests/test_guard.py
@@ -129,8 +129,11 @@ def test_check_accepts_runtime_token_budget(tmp_path):
 
     assert large["status"] == "failed"
     assert "항상 반말로 대답해" in large["not_applicable"]
+    assert large["protected_overflow"] is False
     assert small["status"] == "failed"
     assert "항상 반말로 대답해" not in small["not_applicable"]
+    assert small["protected_overflow"] is True
+    assert small["omitted_protected_instructions"] == ["항상 반말로 대답해"]
 
 
 def test_report_accepts_runtime_token_budget(tmp_path):
@@ -142,6 +145,8 @@ def test_report_accepts_runtime_token_budget(tmp_path):
 
     assert report["protected"] == 2
     assert report["details"]["integrity"]["protected_loaded"] == 1
+    assert report["protected_overflow"] is True
+    assert report["protected_omitted"] == 1
 
 
 def test_context_returns_prompt_string(tmp_path):
@@ -167,6 +172,7 @@ def test_guard_can_set_default_token_budget(tmp_path):
 
     assert result["status"] == "failed"
     assert "항상 반말로 대답해" not in result["not_applicable"]
+    assert result["protected_overflow"] is True
 
 
 def test_guard_delegates_to_memory(tmp_path):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -36,6 +36,9 @@ def test_verify_accepts_runtime_token_budget(tmp_path):
 
     assert report["protected_memories"] == 2
     assert report["integrity"]["protected_loaded"] == 1
+    assert report["integrity"]["protected_overflow"] is True
+    assert report["integrity"]["protected_omitted"] == 1
+    assert report["overflow"]["protected"]["omitted"][0]["instruction"] == "항상 반말로 대답해"
 
 
 def test_project_memory_is_recalled_for_matching_query(tmp_path):
@@ -46,6 +49,18 @@ def test_project_memory_is_recalled_for_matching_query(tmp_path):
     result = mem.recall("web-app에서 패키지 설치 명령 알려줘", top_k=1, include_protected=False)
 
     assert result[0]["content"] == "이 저장소는 pnpm을 사용해"
+
+
+def test_build_context_reports_protected_overflow(tmp_path):
+    mem = Memory(agent_id="assistant", storage_path=str(tmp_path))
+    mem.remember("코드 블록에 항상 언어 태그를 붙여")
+    mem.remember("항상 반말로 대답해")
+
+    context = mem.build_context("파이썬 예제 보여줘", token_budget=10)
+
+    assert context["overflow"]["protected"]["overflowed"] is True
+    assert context["overflow"]["protected"]["omitted_count"] == 1
+    assert context["overflow"]["protected"]["omitted"][0]["instruction"] == "항상 반말로 대답해"
 
 
 def test_export_and_consolidate(tmp_path):
@@ -145,6 +160,8 @@ def test_observe_response_accepts_runtime_token_budget(tmp_path):
     assert observed["checked_memories"] == 1
     skipped_instructions = {item["instruction"] for item in observed["skipped"]}
     assert "항상 반말로 대답해" not in skipped_instructions
+    assert observed["overflow"]["protected"]["overflowed"] is True
+    assert observed["overflow"]["protected"]["omitted"][0]["instruction"] == "항상 반말로 대답해"
 
 
 def test_observe_response_can_include_active_memories(tmp_path):


### PR DESCRIPTION
## Summary
Expose protected-zone overflow explicitly instead of silently omitting protected instructions under tight context budgets.

## What changed
- add overflow metadata to `Memory.build_context()` for protected, active, and buffer selection
- surface protected overflow details through `observe_response()`, `observe_action()`, `verify()`, and `MemoryGuard.report()`
- expose omitted protected instructions in high-level guard results without changing pass/fail policy
- add regression coverage for build-context, check, observe, and verify paths under constrained budgets

## Why
Issue #10 tracks the gap between a "protected" zone and the current silent omission behavior. This PR keeps the current selection policy intact, but makes overflow visible so users can reason about real runtime guarantees before later compaction work lands.

## Validation
- `./.venv/bin/python -m pytest tests -q` → `40 passed`

Closes #10