### PR TITLE
chore: add .env protection to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ build/
 .memguard*/
 .instructionguard*/
 *.egg-info/
+
+# Secrets / env files
+.env
+.env.*
+!.env.example
+!.env.sample
+!.env.template


### PR DESCRIPTION
## Summary
- Prevent accidental commit of local `.env` files that may contain API keys or other secrets
- Keeps `.env.example` / `.env.sample` / `.env.template` allowed so onboarding templates still work

## Context
Security hygiene sweep across public repos. No secrets leaked in this repo's history, but `.gitignore` wasn't excluding `.env`, so a future `git add .` could have committed one by accident. This closes that gap.

## Test plan
- [ ] `git check-ignore .env` exits 0 (ignored)
- [ ] `git check-ignore .env.example` exits non-zero (still tracked)